### PR TITLE
Dockerizing jiraprinter

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+node_modules
+npm-debug.log
+coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:4-slim
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY package.json /usr/src/app/
+RUN npm install
+COPY . /usr/src/app
+
+ENV PORT 80
+
+ENTRYPOINT [ "node", "index.js" ]
+
+CMD [ "--help" ]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ Each story is printed out as a half-page (US Letter) card, with the Story number
 
 ## Usage
 
+### with Docker
+
+You can run jiraprinter in Docker:
+
+```console
+$ docker run -d -p 8080:80 -e JIRA_PASS hairyhenderson/jiraprinter -h myjira.example.com -p 'My Project' -u me
+```
+
+Or, you can use `npm` to install it:
+
 ### install
 
 ```console

--- a/index.js
+++ b/index.js
@@ -19,8 +19,10 @@ app.use('/stories', story_router.routes())
 
 app.use(express.static('public'))
 
+var port = process.env.PORT || 3000
+
 if (process.env.NODE_ENV !== 'test') {
-  var server = app.listen(3000, function () {
+  var server = app.listen(port, function () {
     var host = server.address().address
     var port = server.address().port
 


### PR DESCRIPTION
- `$PORT` is now respected, and set to `80` inside the Dockerfile by
  default
- This'll be (eventually) available from DockerHub as
  `hairyhenderson/jiraprinter`

Signed-off-by: Dave Henderson <dhenderson@gmail.com>