### PR TITLE
Supporting env vars for all options, plus opt validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,4 @@ COPY . /usr/src/app
 
 ENV PORT 80
 
-ENTRYPOINT [ "node", "index.js" ]
-
-CMD [ "--help" ]
+CMD [ "node", "index.js" ]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Each story is printed out as a half-page (US Letter) card, with the Story number
 You can run jiraprinter in Docker:
 
 ```console
-$ docker run -d -p 8080:80 -e JIRA_PASS hairyhenderson/jiraprinter -h myjira.example.com -u me
+$ docker run -d -p 8080:80 -e JIRA_PASS -e JIRA_USER=me -e JIRA_HOST=myjira.example.com hairyhenderson/jiraprinter
 ```
 
 Or, you can use `npm` to install it:
@@ -47,9 +47,9 @@ $ jiraprinter --help
 
     -h, --help               output usage information
     -V, --version            output the version number
-    -u, --user [username]    The JIRA username ($USER)
+    -u, --user [username]    The JIRA username ($JIRA_USER)
     --password [password]    The JIRA password ($JIRA_PASS)
-    -h, --host <host>        The JIRA hostname
+    -h, --host [host]        The JIRA hostname ($JIRA_HOST)
 $ jiraprinter -h myjira.example.com -u me
 ```
 

--- a/index.js
+++ b/index.js
@@ -8,10 +8,32 @@ var app = express()
 
 config
   .version(require('./package.json').version)
-  .option('-u, --user [username]', 'The JIRA username ($USER)', process.env.USER)
+  .option('-u, --user [username]', 'The JIRA username ($JIRA_USER)', process.env.JIRA_USER)
   .option('--password [password]', 'The JIRA password ($JIRA_PASS)', process.env.JIRA_PASS)
-  .option('-h, --host <host>', 'The JIRA hostname')
+  .option('-h, --host [host]', 'The JIRA hostname ($JIRA_HOST)', process.env.JIRA_HOST)
   .parse(process.argv)
+
+function validateOpts (config) {
+  var errors = 0
+  if (!config.user) {
+    console.error('ERROR: Username required. Use -u/--user, or set $JIRA_USER')
+    errors++
+  }
+  if (!config.password) {
+    console.error('ERROR: Password required. Set $JIRA_PASS (or use --password)')
+    errors++
+  }
+  if (!config.host) {
+    console.error('ERROR: JIRA hostname required. Use -h/--host, or set $JIRA_HOST')
+    errors++
+  }
+
+  if (errors) {
+    process.exit(errors)
+  }
+}
+
+validateOpts(config)
 
 var issuetype_router = new IssueTypeRouter(config, express.Router())
 var issue_router = new IssueRouter(config, express.Router())

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Print out Story cards from JIRA",
   "main": "index.js",
   "scripts": {
+    "start": "node index.js",
     "test": "node_modules/.bin/standard && make test-ci"
   },
   "bin": {


### PR DESCRIPTION
- You can use `$JIRA_USER`, `$JIRA_PASS`, and `$JIRA_HOST` instead of
  `--user`, `--password`, and `--host`
- Removed the default to `$USER`
- Added commandline option validation!
- Updated Docker instructions in README to default to env-only usage

Signed-off-by: Dave Henderson <dhenderson@gmail.com>